### PR TITLE
Fix TypeError: add type conversion for init-start argument

### DIFF
--- a/caption_generator.py
+++ b/caption_generator.py
@@ -112,7 +112,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("-m", "--model", default="small", help="Whisper model size (tiny/base/small/medium/large...).")
     p.add_argument("-l", "--language", default="en", help="Language code (e.g., en). Omit to auto-detect.")
     p.add_argument("--no-lowercase", action="store_true", help="Keep original word casing (default lowercases).")
-    p.add_argument("-s", "--init-start", default=0.0, help="Set initial start time, 0.0 otherwise")
+    p.add_argument("-s", "--init-start", type=float, default=0.0, help="Set initial start time, 0.0 otherwise")
     return p.parse_args()
 
 


### PR DESCRIPTION
## Problem
The `--init-start`/`-s` argument was being parsed as a string by default, causing a TypeError when compared with float values in the `build_word_timestamps` function (line 65).

## Error
When running commands like:
```bash
python3 caption_generator.py -i video.mp4 -m large -s 0.1
```

The script would fail with:
```
Unexpected error: '<' not supported between instances of 'float' and 'str'
```

## Solution
Added `type=float` to the argument parser for the `--init-start` parameter to ensure proper type conversion from command line input.

## Changes
- Modified `parse_args()` function in `caption_generator.py`
- Added `type=float` to the `--init-start` argument definition

## Testing
Verified the fix works by running the command that previously failed:
```bash
python3 caption_generator.py -i "/path/to/video.mp4" -m large -s 0.1
```

The script now runs successfully and generates the expected `temp/word_timestamps.json` file.